### PR TITLE
SOURCESの取得方法を変更

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,15 +14,7 @@ PLGINFO 	:= 	AnimalBytes.plgInfo
 
 BUILD		:= 	Build
 INCLUDES	:= 	Includes ACNL_Wrapper/include
-SOURCES 	:= 	Sources	\
-	Sources/ACNL \
-	Sources/DevUtils \
-	Sources/Helpers \
-	Sources/Cheats \
-	Sources/Cheats/Movements \
-	Sources/Cheats/SpeedHacks \
-	Sources/Cheats/Items \
-	Sources/Cheats/TextToCheats
+SOURCES 	:= 	$(shell find Sources -type d 2>/dev/null)
 
 #---------------------------------------------------------------------------------
 # options for code generation


### PR DESCRIPTION
ディレクトリを列挙すると、今後モジュールを追加する際に冗長になってしまうため、findで一括取得するよう変更。