### PR TITLE
Change .elf location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ $(OUTPUT).3gx : $(OFILES)
 #---------------------------------------------------------------------------------
 	@echo creating $(notdir $@)
 	@3gxtool -s $(word 1, $^) $(TOPDIR)/$(PLGINFO) $@
+	@mv $(word 1, $^) .
 
 -include $(DEPENDS)
 


### PR DESCRIPTION
`.PRECIOUS`の影響で自動リンクが行われなくなっていたため、.elfファイルをBuildディレクトリに再配置するよう修正。