### PR TITLE
devkitPro/installerのリリースページへ直接リンクしている問題を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 It's good.
 
 ## Dependencies
-if you are using Windows, download [the devkitPro installer](https://github.com/devkitPro/installer/releases) and run it.
+Please follow [this guide](https://devkitpro.org/wiki/Getting_Started) to set up devkitPro.
 
 ## Building
 ```


### PR DESCRIPTION
**Please do not link directly to this release. Link to Getting Started where more in depth instructions will be provided**
このようにdevkitProが明言しているのでリンクを変更し、それに伴い文も修正。