### PR TITLE
Workflowの追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on: pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: pablomk7/libctrpf:0.7.3
+
+    steps:
+      - uses: actions/checkout@v3
+      - run: make
+      - uses: actions/upload-artifact@v3
+        with:
+          name: AnimalBytes
+          path: AnimalBytes.3gx

--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,12 @@ export LIBPATHS	:=	$(foreach dir,$(LIBDIRS),-L $(dir)/lib)
 #---------------------------------------------------------------------------------
 all: $(BUILD)
 
-$(BUILD):
+$(BUILD): $(CTRPFLIB)/lib/libctrpf.a
 	@[ -d $@ ] || mkdir -p $@
 	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
+
+$(CTRPFLIB)/lib/libctrpf.a:
+	@$(MAKE) -j -C $(CTRPFLIB)  --no-print-directory
 
 #---------------------------------------------------------------------------------
 clean:


### PR DESCRIPTION
プルリクエストの際に自動でビルドテストするためのワークフローを追加。
これに伴いlibctrpfの依存関係チェックを追加。